### PR TITLE
remove awesome_print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 2.0.3
+ - removed unused code to fix specs
+
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 

--- a/lib/logstash/outputs/stdout.rb
+++ b/lib/logstash/outputs/stdout.rb
@@ -9,12 +9,12 @@ require "logstash/namespace"
 #
 # For example, the following output configuration, in conjunction with the
 # Logstash `-e` command-line flag, will allow you to see the results
-# of your event pipeline for quick iteration. 
+# of your event pipeline for quick iteration.
 # [source,ruby]
 #     output {
 #       stdout {}
 #     }
-# 
+#
 # Useful codecs include:
 #
 # `rubydebug`: outputs event data using the ruby "awesome_print"
@@ -32,13 +32,8 @@ require "logstash/namespace"
 #     }
 #
 class LogStash::Outputs::Stdout < LogStash::Outputs::Base
-  begin
-     require "awesome_print"
-  rescue LoadError
-  end
-
   config_name "stdout"
-  
+
   default :codec, "line"
 
   public
@@ -49,7 +44,7 @@ class LogStash::Outputs::Stdout < LogStash::Outputs::Base
   end
 
   def receive(event)
-    
+
     return if event == LogStash::SHUTDOWN
     @codec.encode(event)
   end

--- a/logstash-output-stdout.gemspec
+++ b/logstash-output-stdout.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-stdout'
-  s.version         = '2.0.2'
+  s.version         = '2.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "A simple output which prints to the STDOUT of the shell running Logstash."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
related to elastic/logstash#4123

I do not understand the reason for having awesome_print required here and it currently breaks `rake test:plugins` with

```
NoMethodError: undefined method `on_load' for ActiveSupport:Module
/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/awesome_print-1.6.1/lib/awesome_print.rb:29:in `(root)'
/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-stdout-2.0.2/lib/logstash/outputs/stdout.rb:1:in `(root)'
/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-stdout-2.0.2/lib/logstash/outputs/stdout.rb:36:in `Stdout'
/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-stdout-2.0.2/lib/logstash/outputs/stdout.rb:34:in `(root)'
/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
file:/Users/colin/dev/src/elasticsearch/logstash/vendor/jruby/lib/jruby.jar!/jruby/kernel19/kernel.rb:13:in `require_relative'
/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-stdout-2.0.2/spec/spec_helper.rb:1:in `(root)'
/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-stdout-2.0.2/spec/spec_helper.rb:3:in `(root)'
/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-stdout-2.0.2/spec/outputs/stdout_spec.rb:1:in `(root)'
/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-stdout-2.0.2/spec/outputs/stdout_spec.rb:2:in `(root)'
/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1:in `(root)'
/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `load_spec_files'
/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `load_spec_files'
/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:96:in `setup'
/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:84:in `run'
/Users/colin/dev/src/elasticsearch/logstash/vendor/bundle/jruby/1.9/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:69:in `run'
/Users/colin/dev/src/elasticsearch/logstash/rakelib/test.rake:72:in `(root)'
```
