### PR TITLE
Declare workers not supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: ruby
+cache: bundler
+rvm:
+  - jruby-1.7.23
+script: bundle exec rspec spec && bundle exec rspec spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.4
+- Properly declare workers_not_supported
+
 ## 2.0.3
  - removed unused code to fix specs
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Logstash Plugin
 
-[![Build
-Status](http://build-eu-00.elastic.co/view/LS%20Plugins/view/LS%20Outputs/job/logstash-plugin-output-stdout-unit/badge/icon)](http://build-eu-00.elastic.co/view/LS%20Plugins/view/LS%20Outputs/job/logstash-plugin-output-stdout-unit/)
+[![Travis Build Status](https://travis-ci.org/logstash-plugins/logstash-output-stdout.svg)](https://travis-ci.org/logstash-plugins/logstash-output-stdout)
 
 This is a plugin for [Logstash](https://github.com/elastic/logstash).
 

--- a/lib/logstash/outputs/stdout.rb
+++ b/lib/logstash/outputs/stdout.rb
@@ -36,8 +36,14 @@ class LogStash::Outputs::Stdout < LogStash::Outputs::Base
 
   default :codec, "line"
 
+  if self.respond_to?(:workers_not_supported!) # Check for v2.2+ API
+    declare_workers_not_supported!("Stdout only supports one worker to prevent text overlap!")
+  end
+
   public
   def register
+    workers_not_supported # < v2.2 API
+
     @codec.on_event do |event, data|
       $stdout.write(data)
     end

--- a/logstash-output-stdout.gemspec
+++ b/logstash-output-stdout.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-stdout'
-  s.version         = '2.0.3'
+  s.version         = '2.0.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "A simple output which prints to the STDOUT of the shell running Logstash."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -25,4 +25,3 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'logstash-devutils'
 end
-


### PR DESCRIPTION
This plugin should properly declare that workers are not supported. This is essential to the 2.2 release which will autoscale workers
