### PR TITLE
Take advantage of new LS 2.4/5.x features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 3.0.2
-  - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
-
+## 3.1.0
+  - Use new 'concurrency :single' for concurrency
+  - Use pipeline encoded codec for greater parallelism
+  - Require Logstash 2.4+ (Plugin API 1.60.1+)
 ## 3.0.1
   - Republish all the gems under jruby.
 ## 3.0.0

--- a/lib/logstash/outputs/stdout.rb
+++ b/lib/logstash/outputs/stdout.rb
@@ -33,26 +33,16 @@ require "logstash/namespace"
 #
 class LogStash::Outputs::Stdout < LogStash::Outputs::Base
   config_name "stdout"
+  concurrency :single
 
   default :codec, "line"
 
-  if self.respond_to?(:workers_not_supported!) # Check for v2.2+ API
-    declare_workers_not_supported!("Stdout only supports one worker to prevent text overlap!")
-  end
+  def register; end # must be overriden
 
-  public
-  def register
-    workers_not_supported # < v2.2 API
-
-    @codec.on_event do |event, data|
+  def multi_receive_encoded(encoded)
+    encoded.each do |event,data|
       $stdout.write(data)
     end
-  end
-
-  def receive(event)
-
-    return if event == LogStash::SHUTDOWN
-    @codec.encode(event)
   end
 
 end # class LogStash::Outputs::Stdout

--- a/logstash-output-stdout.gemspec
+++ b/logstash-output-stdout.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-stdout'
-  s.version         = '3.0.2'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "A simple output which prints to the STDOUT of the shell running Logstash."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60.1", "< 2.99"
   s.add_runtime_dependency 'logstash-codec-line'
 
   s.add_development_dependency 'logstash-devutils'

--- a/spec/outputs/stdout_spec.rb
+++ b/spec/outputs/stdout_spec.rb
@@ -13,17 +13,18 @@ describe LogStash::Outputs::Stdout do
     subject { LogStash::Outputs::Stdout.new({}) }
 
     let(:properties) { { "message" => "This is a message!"} }
-    let(:event)      { LogStash::Event.new(properties) }
+    let(:event) { double("event") }
+    let(:encoded) { double("encoded") }
 
     before(:each) do
       subject.register
     end
 
     it "sends the generated event out" do
-      expect(subject.codec).to receive(:encode).with(event)
-      subject.receive(event)
+      expect($stdout).to receive(:write).with(encoded)
+      subject.multi_receive_encoded([[event, encoded]])
     end
-
+    
   end
 
 end


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
- Use new 'concurrency :single' for concurrency
- Use pipeline encoded codec for greater parallelism
- Require Logstash 2.4+ (Plugin API 1.60.1+)
