### PR TITLE
Changed default stdout codec to rubydebug

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -28,6 +28,8 @@ data after it has passed through the inputs and filters.
 For example, the following output configuration, in conjunction with the
 Logstash `-e` command-line flag, will allow you to see the results
 of your event pipeline for quick iteration.
+
+The default codec utilsed within stdout is rubydebug.
 [source,ruby]
     output {
       stdout {}
@@ -35,12 +37,10 @@ of your event pipeline for quick iteration.
 
 Useful codecs include:
 
-`rubydebug`: outputs event data using the ruby "awesome_print"
-http://rubygems.org/gems/awesome_print[library]
-
+`plain`: outputs event data with no delimiting between events.
 [source,ruby]
     output {
-      stdout { codec => rubydebug }
+      stdout { codec => plain }
     }
 
 `json`: outputs event data in structured JSON format

--- a/lib/logstash/outputs/stdout.rb
+++ b/lib/logstash/outputs/stdout.rb
@@ -17,12 +17,10 @@ require "logstash/namespace"
 #
 # Useful codecs include:
 #
-# `rubydebug`: outputs event data using the ruby "awesome_print"
-# http://rubygems.org/gems/awesome_print[library]
-#
+# `plain`: outputs event data with no delimiting between events.
 # [source,ruby]
 #     output {
-#       stdout { codec => rubydebug }
+#       stdout { codec => plain }
 #     }
 #
 # `json`: outputs event data in structured JSON format
@@ -35,7 +33,7 @@ class LogStash::Outputs::Stdout < LogStash::Outputs::Base
   config_name "stdout"
   concurrency :single
 
-  default :codec, "line"
+  default :codec, "rubydebug"
 
   def register; end # must be overriden
 

--- a/logstash-output-stdout.gemspec
+++ b/logstash-output-stdout.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60.1", "< 2.99"
-  s.add_runtime_dependency 'logstash-codec-line'
+  s.add_runtime_dependency 'logstash-codec-rubydebug'
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
Changed default stdout codec to rubydebug in response to issue: ["Default to rubydebug for stdout plugin #5"](https://github.com/logstash-plugins/logstash-output-stdout/issues/5)
